### PR TITLE
store only one CompositeMessageLookup for every LocalizationsDelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ In common scenario - we don't. Just put all localization string in single file a
 But if you want to add intl localization with arb files to separate package, and than use
 it in you project with it's own localization files - that's problem.
 
+`MultipleLocalizations` supports using `Localizations.override(delegates: [SomeLocalizationsDelegate(), ...])` widget, too.
+
 Exactly for that situation this package was developed.
 
 See article on Medium for more details - [Localization for Dart package](https://medium.com/@greymag/localization-for-dart-package-8ca2f56ea971).

--- a/lib/src/multiple_localization.dart
+++ b/lib/src/multiple_localization.dart
@@ -74,23 +74,14 @@ class MultipleLocalizations {
 }
 
 class _MultipleLocalizationLookup implements intl_private.MessageLookup {
-  final List<CompositeMessageLookup> _lookups = [];
+  final Map<Function, CompositeMessageLookup> _lookups = {};
 
   @override
   void addLocale(String localeName, Function findLocale) {
-    CompositeMessageLookup lookup;
-    for (final item in _lookups) {
-      if (!item.localeExists(localeName)) {
-        lookup = item;
-        break;
-      }
-    }
-
-    if (lookup == null) {
-      lookup = CompositeMessageLookup();
-      _lookups.add(lookup);
-    }
-
+    final lookup = _lookups.putIfAbsent(
+      findLocale,
+      () => CompositeMessageLookup(),
+    );
     lookup.addLocale(localeName, findLocale);
   }
 
@@ -98,7 +89,7 @@ class _MultipleLocalizationLookup implements intl_private.MessageLookup {
   String lookupMessage(String messageStr, String locale, String name,
       List<Object> args, String meaning,
       {MessageIfAbsent ifAbsent}) {
-    for (final lookup in _lookups) {
+    for (final lookup in _lookups.values) {
       final res = lookup.lookupMessage(messageStr, locale, name, args, meaning,
           ifAbsent: (s, a) => null);
       if (res != null) return res;


### PR DESCRIPTION
Fix #1 

store only one CompositeMessageLookup for every LocalizationsDelegate

(distinguish them by "findLocale" function that is generated and unique for every LocalizationsDelegate)