### PR TITLE
add clearFirst for load() to clear lookups.

### DIFF
--- a/lib/src/multiple_localization.dart
+++ b/lib/src/multiple_localization.dart
@@ -56,8 +56,12 @@ class MultipleLocalizations {
   /// Use [setDefaultLocale] to set loaded locale as [Intl.defaultLocale].
   static Future<T> load<T>(InitializeMessages initializeMessages, Locale locale,
       FutureOr<T> Function(String locale) builder,
-      {bool setDefaultLocale = false}) {
+      {bool setDefaultLocale = false, bool clearFirst = true, }) {
     if (_lookup == null) _init();
+
+    if (clearFirst)
+      _lookup?._lookups.clear();
+
     final name = locale.toString();
     final localeName = Intl.canonicalizedLocale(name);
 


### PR DESCRIPTION
The load sequence of l10n delegates may not same with the sequence in MaterialApp(localizationsDelegates: [...]).
eg:
delegateA support en, ko, zh.
delegateB support en, ko.

```
MaterialApp(localizationsDelegates: [
  multiDelegate,

  delegateB,
  delegateA,
  ...,
]);
```

The code above works ok when locale is en/ko. BUT, when locale **changes** from zh => ko, delegateA overrides delegateB.
delegateA has been added to _lookups when locale is zh, and will not go behind of delegateB when locale changed to ko and add delegateB.

'clearFirst' will clear _lookups when locale changes and fix the problem.