### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.17.0
+  intl: ^0.18.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
it solves pub get error:

Because multiple_localization 0.3.0 depends on intl ^0.17.0 and no versions of multiple_localization match >0.3.0 <0.4.0, multiple_localization ^0.3.0 requires intl ^0.17.0.
So, because micro_core depends on both intl ^0.18.1 and multiple_localization ^0.3.0, version solving failed.